### PR TITLE
fix: 🐛 support for x-picnic-did and x-picnic-agent headers

### DIFF
--- a/delivery_scenario_test.go
+++ b/delivery_scenario_test.go
@@ -1,7 +1,9 @@
 package picnic
 
 import (
+	"github.com/joho/godotenv"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -37,5 +39,29 @@ func TestGetDeliveryScenario_Error_MissingId(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("No error raised")
+	}
+}
+
+func Test_Integration_Deliveries(t *testing.T) {
+	godotenv.Load()
+	c := New(&http.Client{},
+		WithUsername(os.Getenv("USERNAME")),
+		WithHashedPassword(os.Getenv("SECRET")),
+		WithVersion("15"),
+	)
+	authErr := c.Authenticate()
+	if authErr != nil {
+		t.Error("auth failed")
+	}
+	deliveries, dErr := c.GetDeliveries([]DeliveryStatus{COMPLETED, CURRENT})
+	if dErr != nil {
+		t.Error(dErr)
+	}
+	pos, posErr := c.GetDeliveryPosition((*deliveries)[0].DeliveryId)
+	if posErr != nil {
+		t.Fatal(posErr)
+	}
+	if pos == nil {
+		t.Error("invalid pos")
 	}
 }

--- a/picnic_test.go
+++ b/picnic_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+const mockToken = `fakeheader.eyJzdWIiOiI4MDgtODEwLTAzMzkiLCJwYzpjbGlkIjoyMDEwMCwicGM6cHY6ZW5hYmxlZCI6ZmFsc2UsInBjOmxvZ2ludHMiOjE1NjEwNDUyNTYxMDcsImlzcyI6InBpY25pYy1kZXYiLCJwYzpwdjp2ZXJpZmllZCI6dHJ1ZSwicGM6MmZhIjoiTk9UX1JFUVVJUkVEIiwicGM6cm9sZSI6IlNUQU5EQVJEX1VTRVIiLCJwYzpkaWQiOiJCQTAyNjAxOC1GMEVFLTRDOTAtQTFENC00Q0MzNjg3RUE4ODEiLCJleHAiOjE3MjAyNjM5NzgsImlhdCI6MTcwNDcxMTk3OCwianRpIjoiMlJJN0c0UFUifQ.FakeSiganture`
+
 func testClient(code int, body io.Reader, validators ...func(*http.Request)) (*Client, *httptest.Server) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, v := range validators {
@@ -24,7 +26,7 @@ func testClient(code int, body io.Reader, validators ...func(*http.Request)) (*C
 	client := &Client{
 		http:    http.DefaultClient,
 		baseURL: server.URL + "/",
-		token:   "mockToken",
+		token:   mockToken,
 	}
 	return client, server
 }
@@ -45,7 +47,7 @@ func testImageClient(code int, body io.Reader, validators ...func(*http.Request)
 	client := &Client{
 		http:    http.DefaultClient,
 		baseURL: server.URL + "/",
-		token:   "mockToken",
+		token:   mockToken,
 	}
 	return client, server
 }
@@ -226,6 +228,13 @@ func Test_Integration(t *testing.T) {
 	authErr := c.Authenticate()
 	if authErr != nil {
 		t.Error("auth failed")
+	}
+	user, userErr := c.GetUser()
+	if userErr != nil {
+		t.Fatal(userErr)
+	}
+	if user == nil {
+		t.Error("invalid user")
 	}
 }
 

--- a/token.go
+++ b/token.go
@@ -1,0 +1,32 @@
+package picnic
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+type token struct {
+	Sub    string `json:"sub"`
+	PcClid int    `json:"pc:clid"`
+	PcDid  string `json:"pc:did"`
+}
+
+func (c *Client) parseJwt() error {
+	tokenParts := strings.Split(c.token, ".")
+	if len(tokenParts) != 3 {
+		return errors.New("invalid token structure")
+	}
+	jsonContent, decodeErr := base64.RawStdEncoding.DecodeString(tokenParts[1])
+	if decodeErr != nil {
+		return decodeErr
+	}
+	var toReturn = token{}
+	jsonErr := json.Unmarshal(jsonContent, &toReturn)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	c.parsedToken = &toReturn
+	return nil
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,26 @@
+package picnic
+
+import "testing"
+
+func TestParseJwt(t *testing.T) {
+	client := &Client{
+		token: mockToken,
+	}
+	tokenErr := client.parseJwt()
+	if tokenErr != nil {
+		t.Fatal(tokenErr)
+	}
+	if client.parsedToken.PcDid == "" {
+		t.Error("PcDid invalid")
+	}
+}
+
+func TestParseJwtInvalid(t *testing.T) {
+	client := &Client{
+		token: "fakeboi",
+	}
+	tokenErr := client.parseJwt()
+	if tokenErr == nil {
+		t.Error("token should not parse")
+	}
+}


### PR DESCRIPTION
# Context

Delivery related endpoints require that `x-picnic-did` and `x-picnic-agent` are included otherwise a 400 error is thrown. 
These values can be extracted from the current user's JWT. 

# Solution

- Helper method to extract the content of the JWT token
- methods calling endpoints related to deliveries now includes the required headers