### PR TITLE
fix: 🐛 search page parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Thanks to the efforts of [MRVDH](https://github.com/MRVDH/picnic-api/) which doc
 
 ## Support
 
-![Static Badge](https://img.shields.io/badge/buy_me_a-coffee-green?style=flat&logo=buymeacoffee&logoColor=f5f5f5&link=https%3A%2F%2Fwww.buymeacoffee.com%2Fsmartyr)
+[![Static Badge](https://img.shields.io/badge/buy_me_a-coffee-green?style=flat&logo=buymeacoffee&logoColor=f5f5f5&link=https%3A%2F%2Fwww.buymeacoffee.com%2Fsmartyr)](https://buymeacoffee.com/smartyr)

--- a/search_page_test.go
+++ b/search_page_test.go
@@ -14,10 +14,14 @@ func TestSearchPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 79 {
+	if len(res) != 118 {
 		t.Error("Invalid result length")
 	}
+	idMap := make(map[string]bool)
 	for _, item := range res {
+		if _, exists := idMap[item.Id]; exists {
+			t.Error("duplicate id")
+		}
 		if item.Name == "" {
 			t.Error("Invalid Item Name")
 		}
@@ -27,6 +31,8 @@ func TestSearchPage(t *testing.T) {
 		if item.DisplayPrice == 0 {
 			t.Error("Invalid Display Price")
 		}
+		idMap[item.Id] = true
+
 	}
 }
 


### PR DESCRIPTION
## Context

Search page payload structure changed to make the search content more nested. Therefore previous approach returned no results. 

## Solution 

- Replaced fixed structure with a recursive search of the structure to grab all nodes of type selling unit.
- Replaced test payload.