### PR TITLE
fix: 🐛 default api to 15 and search page changes

### DIFF
--- a/picnic.go
+++ b/picnic.go
@@ -93,8 +93,8 @@ func WithHashedPassword(hashedPassword string) ClientOption {
 func New(client *http.Client, opts ...ClientOption) *Client {
 	c := &Client{
 		http:    client,
-		baseURL: "https://storefront-prod.nl.picnicinternational.com/api/17",
-		version: "17",
+		baseURL: "https://storefront-prod.nl.picnicinternational.com/api/15",
+		version: "15",
 		country: "nl",
 	}
 

--- a/picnic_test.go
+++ b/picnic_test.go
@@ -130,10 +130,10 @@ func TestGetArticleImage_NotFound(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	c := New(&http.Client{})
-	if c.baseURL != "https://storefront-prod.nl.picnicinternational.com/api/17" {
+	if c.baseURL != "https://storefront-prod.nl.picnicinternational.com/api/15" {
 		t.Error("Invalid baseurl")
 	}
-	if c.version != "17" {
+	if c.version != "15" {
 		t.Error("Invalid version")
 	}
 	if c.country != "nl" {
@@ -155,7 +155,7 @@ func TestNew_With_Version(t *testing.T) {
 func TestNew_With_Country(t *testing.T) {
 	country := "be"
 	c := New(&http.Client{}, WithCountry(country))
-	if c.baseURL != "https://storefront-prod.be.picnicinternational.com/api/17" {
+	if c.baseURL != "https://storefront-prod.be.picnicinternational.com/api/15" {
 		t.Error("Invalid baseurl")
 	}
 	if c.country != country {

--- a/search_page.go
+++ b/search_page.go
@@ -6,7 +6,11 @@ import (
 )
 
 type SearchPage struct {
-	Body RecursiveChildren `json:"body"`
+	Body FirstChild `json:"body"`
+}
+
+type FirstChild struct {
+	Child RecursiveChildren `json:"child"`
 }
 
 type RecursiveChildren struct {
@@ -16,7 +20,7 @@ type RecursiveChildren struct {
 
 type SearchContent struct {
 	Type        string        `json:"type"`
-	SellingUnit SingleArticle `json:"selling_unit"`
+	SellingUnit SingleArticle `json:"sellingUnit"`
 }
 
 const sellingUnitType = "SELLING_UNIT_TILE"
@@ -43,7 +47,7 @@ func (c *Client) SearchArticles(query string) ([]SingleArticle, error) {
 
 func (page *SearchPage) extractArticles() []SingleArticle {
 	var articles []SingleArticle
-	for _, child := range page.Body.Children {
+	for _, child := range page.Body.Child.Children {
 		child.findArticles(&articles)
 	}
 	return articles

--- a/search_page_test.go
+++ b/search_page_test.go
@@ -14,7 +14,7 @@ func TestSearchPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 118 {
+	if len(res) != 78 {
 		t.Error("Invalid result length")
 	}
 	idMap := make(map[string]bool)
@@ -79,7 +79,6 @@ func Test_Integration_SearchPage(t *testing.T) {
 	c := New(&http.Client{},
 		WithUsername(os.Getenv("USERNAME")),
 		WithHashedPassword(os.Getenv("SECRET")),
-		WithVersion("15"),
 	)
 	authErr := c.Authenticate()
 	if authErr != nil {


### PR DESCRIPTION
## Context

Picnic API client was defaulting to 17 - where as the App itself uses version 15 - as flagged as part of issue #9 

## Solution 

- Set default version to 15
- Fixed search page 